### PR TITLE
Update build.yml to exclude Python 3.9 (EOL)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest] # TODO re-enable: , macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Removed Python version '3.9' from the build matrix.